### PR TITLE
Use HTTPS where possible

### DIFF
--- a/_svg.scss
+++ b/_svg.scss
@@ -11,21 +11,21 @@
  	$length: str-length($search);
  	$index: str-index($string, $search);
  	$slice: $string;
- 	
+
  	@while $index != null {
  	  $start: if($index > 1, str-slice($slice, 1, $index - 1), '');
  		$slice: $start + $replace + str-slice($slice, $index + $length);
- 	
+
  		$index: str-index($slice, $search);
  	}
- 	
+
  	@return $slice;
  }
 
 // Create an inline SVG data URI
 @function svg($content, $viewBox: "0 0 100 100") {
 	$content: str-replace($content, '#', '%23'); // Firefox needs this
-	
+
 	@return url('data:image/svg+xml,<svg viewBox="#{$viewBox}" xmlns="http://www.w3.org/2000/svg">#{$content}</svg>');
 }
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 
 <header>
 	<h1><iframe src="logo.svg"></iframe></h1>
-	
+
 	<div>
 		<p>Form element autosizing,<br /> the way it should be.</p>
 		<nav>
@@ -46,7 +46,7 @@
 	<label>Textarea:
 		<textarea placeholder="Type here too"></textarea>
 	</label>
-	
+
 	<label>Input with placeholder:
 		<input placeholder="Type some text" />
 	</label>
@@ -100,7 +100,7 @@
 
 		<dt>Stretchy.applyAll(elements)</dt>
 		<dd>Apply <code>Stretchy.apply()</code> to a collection of elements, or all Stretchy is set to apply to, if no argument is provided.</dd>
-		
+
 		<dt>Stretchy.applies()</dt>
 		<dd>Can Stretchy be used on this particular element? (checks if element is in the DOM, if it's of the right type and if it matches the selector filter provided by <code>data-stretchy-selector</code>, if the attribute is set.</dd>
 
@@ -119,9 +119,9 @@
 </section>
 
 <footer>
-	Made with &hearts; by <a href="http://lea.verou.me">Lea Verou</a> 
+	Made with &hearts; by <a href="http://lea.verou.me">Lea Verou</a>
 	&bull; <a href="http://lea.verou.me/2015/07/stretchy-form-element-autosizing-the-way-it-should-be">About</a>
-	&bull; <a href="javascript:(function(script){script.src='http://leaverou.github.io/stretchy/stretchy.min.js';document.body.appendChild(script);})(document.createElement('script'))">Use as a bookmarklet!</a>
+	&bull; <a href="javascript:(function(script){script.src='https://leaverou.github.io/stretchy/stretchy.min.js';document.body.appendChild(script);})(document.createElement('script'))">Use as a bookmarklet!</a>
 
 	<a href="https://github.com/LeaVerou/stretchy" class="github-ribbon">Fork me on GitHub</a>
 
@@ -129,15 +129,15 @@
 		<a href="https://twitter.com/share" class="twitter-share-button" data-via="LeaVerou">Tweet</a>
 		<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 		</script>
-		<iframe src="http://ghbtns.com/github-btn.html?user=leaverou&amp;repo=stretchy&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="97" height="20"></iframe>
-		<iframe style='vertical-align: middle' src="http://ghbtns.com/github-btn.html?user=leaverou&amp;repo=stretchy&amp;type=fork&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="95" height="20"></iframe>
+		<iframe src="https://ghbtns.com/github-btn.html?user=leaverou&amp;repo=stretchy&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="97" height="20"></iframe>
+		<iframe style='vertical-align: middle' src="https://ghbtns.com/github-btn.html?user=leaverou&amp;repo=stretchy&amp;type=fork&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="95" height="20"></iframe>
 	</div>
 </footer>
 
 
 
-<script async src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=C6AILKT&placement=leaveroume" id="_carbonads_js"></script>
-	
+<script async src="https://cdn.carbonads.com/carbon.js?zoneid=1673&amp;serve=C6AILKT&amp;placement=leaveroume" id="_carbonads_js"></script>
+
 <script src="stretchy.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-@import url(http://fonts.googleapis.com/css?family=Arvo:400,700|Damion);
+@import url(https://fonts.googleapis.com/css?family=Arvo:400,700|Damion);
 /*
  * Cascading Graphics Sheets: Generate SVG data URIs in SCSS!
  * By Lea Verou — http://lea.verou.me

--- a/style.scss
+++ b/style.scss
@@ -1,9 +1,9 @@
 // Colors
-$accent1: hsl(185, 40%, 50%); // turquoise 
+$accent1: hsl(185, 40%, 50%); // turquoise
 $accent2: hsl(10, 50%, 40%); // dark red
 $base: hsl(40, 60%, 90%); // beige
 
-@import url(http://fonts.googleapis.com/css?family=Arvo:400,700|Damion);
+@import url(https://fonts.googleapis.com/css?family=Arvo:400,700|Damion);
 @import "_svg";
 
 body {
@@ -244,7 +244,7 @@ footer {
 }
 
 .social-media {
-	
+
 
 	@media (min-width: 1150px) {
 		& {


### PR DESCRIPTION
This avoids mixed-content errors on https://leaverou.github.io/stretchy/ and makes the bookmarklet work on HTTPS pages.
