### PR TITLE
Fix typo: Stretchy.selector -> Stretchy.selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
 
 	<p>If you want to avoid modifying the markup, you can use JavaScript instead, as long as this is set before <code>DOMContentLoaded</code> fires:</p>
 
-	<pre><code class="language-javascript">Stretchy.selector.filter = ".foo, .foo *";</code></pre>
+	<pre><code class="language-javascript">Stretchy.selectors.filter = ".foo, .foo *";</code></pre>
 </section>
 
 <section id="api">


### PR DESCRIPTION
`Stretchy.selector` (singular) doesn't exist. `Stretchy.selectors` (plural) does, though.
