### PR TITLE
fix for #24, calculation of input with content-box box-sizing

### DIFF
--- a/stretchy.js
+++ b/stretchy.js
@@ -72,6 +72,9 @@ var _ = self.Stretchy = {
 				else if (cs.boxSizing == "padding-box") {
 					offset = element.clientWidth;
 				}
+				else if (cs.boxSizing == "content-box") {
+					offset = parseFloat(cs.minWidth);
+				}
 
 				// Safari misreports scrollWidth, so we will instead set scrollLeft to a
 				// huge number, and read that back to see what it was clipped to


### PR DESCRIPTION
I tested this on the latest Firefox, Safari, and Chrome.

Stretchy doesn't seem to work on Edge at all and I don't have a machine with IE handy, but this should work there, as well, since it has supported min-width since IE7 and there do not appear to be any reports about it having a buggy implementation in newer versions.