### PR TITLE
Manually hoist variable to avoid babili minification bug

### DIFF
--- a/stretchy.js
+++ b/stretchy.js
@@ -39,10 +39,11 @@ var _ = self.Stretchy = {
 
 		var cs = getComputedStyle(element);
 		var offset = 0;
+		var empty;
 
 		if (!element.value && element.placeholder) {
-			var empty = true;
 			element.value = element.placeholder;
+			empty = true;
 		}
 
 		var type = element.nodeName.toLowerCase();

--- a/stretchy.js
+++ b/stretchy.js
@@ -42,8 +42,8 @@ var _ = self.Stretchy = {
 		var empty;
 
 		if (!element.value && element.placeholder) {
-			element.value = element.placeholder;
 			empty = true;
+			element.value = element.placeholder;
 		}
 
 		var type = element.nodeName.toLowerCase();


### PR DESCRIPTION
Tiny tweak to separate variable declaration from initialisation and avoid a bug when minifying `stretchy.js` using babili.

This is the root cause of [mavo issue 191](https://github.com/mavoweb/mavo/issues/191) which was running stretchy through babili to produce minified build.

(I've also logged the [hoisting bug with babili](https://github.com/babel/babili/issues/558))
