### PR TITLE
Correct Broken CSS Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta charset="UTF-8" />
 <title>Stretchy: Form element autosizing, the way it should be.</title>
 <link rel="icon" href="logo.svg#cat">
-<link rel="stylesheet" href="style.css" />
+<link rel="stylesheet" href="style.postcss" />
 <script type="module" src="https://md-block.verou.me/md-block.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Discovered that there's a broken link to the style.css sheet, as well as a reference to ' https://projects.verou.me/stretchy/dist/stretchy.iife.js '. 

Can't find the javascript file, but it looks as though this .postcss file may be the CSS sheet (Page looked pretty when linking to it, must have been the one ;) )